### PR TITLE
WIP: Determine the number of cores for parallel make.

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -44,3 +44,6 @@ fi
 if [ ! -d "$FASRCSW_DEV"/appdata ]; then
     mkdir "$FASRCSW_DEV"/appdata
 fi
+
+#parallelize make
+${BUILD_CPUS:-$(cat /proc/cpuinfo | tac | grep processor | sed -n 1p | sed 's/[^0-9]*//g')}


### PR DESCRIPTION
Create a variable that defines the number of cpu cores available on the machine, so that this variable may be passed to `make -j` in order to take advantage of faster parallel builds.